### PR TITLE
Fix: Add checks for empty menu objects in Helpers/Wordpress.php

### DIFF
--- a/src/Helpers/Wordpress.php
+++ b/src/Helpers/Wordpress.php
@@ -101,6 +101,10 @@ class Wordpress
     {
         $menuObject = wp_get_nav_menu_object($menuId);
 
+        if(empty($menuObject)) {
+            return [];
+        }
+
         /**
          * Filter the arguments supplied to each call to `wp_get_nav_menu_items` when generating menus
          *


### PR DESCRIPTION
Helpers/Wordpress.php would throw warnings if no menus were assigned. 