### PR TITLE
feat: allow using customisation of vite directory, fix hooks so asset…

### DIFF
--- a/src/Commands/StartSsrCommand.php
+++ b/src/Commands/StartSsrCommand.php
@@ -25,7 +25,9 @@ class StartSsrCommand
         }
 
         $namespace = Settings::get('entry_namespace');
-        $target = Path::join(wp_upload_dir()['basedir'], 'scw-vite-hmr', $namespace, 'ssr', 'ssr.mjs');
+        $viteDistPath = apply_filters('vite_dist_path', wp_upload_dir()['basedir'] . DIRECTORY_SEPARATOR . 'scw-vite-hmr');
+
+        $target = Path::join($viteDistPath, $namespace, 'ssr', 'ssr.mjs');
 
         if (!file_exists($target)) {
             WP_CLI::error("Couldn't find Inertia SSR file. Ensure you have run a build of your theme and try again.");

--- a/src/Theme/ThemeSetup.php
+++ b/src/Theme/ThemeSetup.php
@@ -14,6 +14,11 @@ class ThemeSetup
     public static function init()
     {
         add_filter('template_include', [__CLASS__, 'handleTemplateInclude']);
+        add_action('after_setup_theme', [__CLASS__, 'setupTheme']);
+    }
+
+    public static function setupTheme()
+    {
         self::addTemplateDirectories();
         self::enqueueScripts();
         self::getThemeVersion();
@@ -43,8 +48,9 @@ class ThemeSetup
 
     public static function getThemeVersion()
     {
+        $viteDistDir = apply_filters('vite_dist_path', wp_upload_dir()['basedir'] . DIRECTORY_SEPARATOR . 'scw-vite-hmr');
         $entryNamespace = Settings::get('entry_namespace');
-        $viteDir =  Path::join(wp_upload_dir()['basedir'], 'scw-vite-hmr', $entryNamespace);
+        $viteDir =  Path::join($viteDistDir, $entryNamespace);
         $container = Container::getInstance();
         $request = $container->get('requestHandler');
         $manifestPath = Path::join($viteDir, 'build', 'manifest.json');


### PR DESCRIPTION
This MR aims to provide user customisation about the dist directory. One can bundle the dist inside the theme, instead of uploads, for example.

It is related to this MR inside your wp-vite repo : https://github.com/evo-mark/wp-vite/pull/1/commits/852c98fff2418513f97f50126a6513152b2aa855

The wp-vite repo needs to get merged first, then the version updated in this plugin in order to glue everything together.

Everything works as expected by keeping the upload dir as default. If one wants to customise the directory, it can be done with a WP filter + updating the vite output dir (see related MR).

Thanks for your feedback !